### PR TITLE
Accelerate

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ StatsBase 0.6
 Distributions 0.5
 HDF5 0.4
 Compat 0.4
+Devectorize 0.4.1

--- a/src/rbm.jl
+++ b/src/rbm.jl
@@ -86,7 +86,16 @@ function vis_means(rbm::RBM, hid::Mat{Float64})
 end
 
 function sample(::Type{Bernoulli}, means::Mat{Float64})
-    return convert(Mat{Float64},rand(size(means)) .< means)
+    # return convert(Mat{Float64},rand(size(means)) .< means)
+
+    # SIMD Approach?
+    s = zeros(means)
+    r = rand(size(means))
+    @simd for i=1:length(means)
+        @inbounds s[i] = r[i] < means[i] ? 1.0 : 0.0
+    end
+    
+    return s
 end
 
 function sample(::Type{Gaussian}, means::Mat{Float64})
@@ -132,7 +141,16 @@ function vis_meansAccel(rbm::RBM, hid::Mat{Float64})
 end
 
 function sampleAccel(::Type{Bernoulli}, means::Mat{Float64})
-    return convert(Mat{Float64},rand(size(means)) .< means)
+    # return convert(Mat{Float64},rand(size(means)) .< means)
+
+    # SIMD Approach?
+    s = zeros(means)
+    r = rand(size(means))
+    @simd for i=1:length(means)
+        @inbounds s[i] = r[i] < means[i] ? 1.0 : 0.0
+    end
+    
+    return s
 end
 
 function sampleAccel(::Type{Gaussian}, means::Mat{Float64})

--- a/src/rbm.jl
+++ b/src/rbm.jl
@@ -2,6 +2,8 @@
 using Distributions
 using Base.LinAlg.BLAS
 using Compat
+using AppleAccelerate
+
 import Base.getindex
 import StatsBase.fit
 
@@ -48,6 +50,10 @@ GRBM(n_vis::Int, n_hid::Int; sigma=0.001, momentum=0.9) =
 
 function logistic(x)
     return 1 ./ (1 + exp(-x))
+end
+
+function logisticAccel(x)
+    return AppleAccelerate.rec(1+AppleAccelerate.exp(-x))
 end
 
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 Mocha 0.0.5
 MNIST 0.0.1
+AppleAccelerate 0.1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
 
 include("testaccel.jl")
-# include("testrbm.jl")
-# include("testnets.jl")
+include("testrbm.jl")
+include("testnets.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
 
 include("testaccel.jl")
-include("testrbm.jl")
-include("testnets.jl")
+# include("testrbm.jl")
+# include("testnets.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 
+include("testaccel.jl")
 include("testrbm.jl")
 include("testnets.jl")

--- a/test/testaccel.jl
+++ b/test/testaccel.jl
@@ -56,8 +56,10 @@ if usingApple
 
     vecBoost = tV./tVAccel
     matBoost = tM./tMAccel
+    mse = mean((Boltzmann.logistic(Xvec) - Boltzmann.logisticAccel(Xvec)).^2)
     println("===================================================")
     println("Vector Accel Calculation: $vecBoost Times Faster")
     println("Matrix Accel Calculation: $matBoost Times Faster")
+    println("Discrepency: $mse (MSE)")
     println("===================================================")
 end

--- a/test/testaccel.jl
+++ b/test/testaccel.jl
@@ -4,6 +4,7 @@ using Base.Test
 usingApple = @osx? true : false
 
 if usingApple
+    ### 1. Test the bottleneck logsig function
     L = 256
     N = L^2
     Trials = 25
@@ -61,5 +62,36 @@ if usingApple
     println("Vector Accel Calculation: $vecBoost Times Faster")
     println("Matrix Accel Calculation: $matBoost Times Faster")
     println("Discrepency: $mse (MSE)")
+    println("===================================================")
+
+    ### 2. Test the Accelerated version of fit()
+    NFeatures = 784
+    NHidden = 300
+    NTrain = 10000
+
+    X = rand(NFeatures,NTrain)
+    rbm = BernoulliRBM(NFeatures,NHidden)
+
+    println("")
+    println("RBM Tests")
+    println("===================================================")    
+    info("WARMUP")
+    fit(rbm,X;accelerate=false)     # Warmup
+    info("No Accel")
+    tic()
+        fit(rbm,X;accelerate=false)
+    tRBM = toq()
+
+    info("WARMUP")
+    fit(rbm,X;accelerate=true)      # Warmup
+    info("With Accel")
+    tic()
+        fit(rbm,X;accelerate=true)
+    tRBMAccel = toq()
+
+    rbmBoost = tRBM ./ tRBMAccel
+
+    println("===================================================")
+    println("10 Iteration Accel PCD: $rbmBoost Times Faster")
     println("===================================================")
 end

--- a/test/testaccel.jl
+++ b/test/testaccel.jl
@@ -77,10 +77,10 @@ if usingApple
     println("RBM Tests")
     println("===================================================")    
     info("WARMUP")
-    fit(rbm,X;accelerate=false,n_iter=Epochs)     # Warmup
+    fit(rbm,X;n_iter=Epochs)     # Warmup
     info("No Accel")
     tic()
-        fit(rbm,X;accelerate=false,n_iter=Epochs)
+        fit(rbm,X;n_iter=Epochs)
     tRBM = toq()
     info("==> Walltime: $tRBM sec")
     println("")

--- a/test/testaccel.jl
+++ b/test/testaccel.jl
@@ -1,0 +1,63 @@
+using Boltzmann
+using Base.Test
+
+usingApple = @osx? true : false
+
+if usingApple
+    L = 256
+    N = L^2
+    Trials = 25
+    Xvec = 2*randn(N)
+    Xmat = 2*randn(L,L)
+
+
+    Boltzmann.logistic(Xmat)
+    Boltzmann.logisticAccel(Xvec)
+    Boltzmann.logisticAccel(Xmat)
+
+    # Standard sigmoid operation
+    println("Testing AppleAccelerate Logsigmoid ($Trials Runs)")
+    println("===================================================")
+    # No Accel, Vector
+        Boltzmann.logistic(Xvec)        # Warmstart
+        tic(); 
+        for itr=1:Trials
+            Boltzmann.logistic(Xvec)
+        end
+        tV=toq()
+    println("   [NoAccel] Vector ($N x 1): $tV sec")
+
+    # No Accel, Matrix
+        Boltzmann.logistic(Xmat)        # Warmstart
+        tic(); 
+        for itr=1:Trials
+            Boltzmann.logistic(Xmat)
+        end
+        tM=toq()
+    println("   [NoAccel] Matirx ($L x $L): $tM sec")
+
+    # Accel, Vector
+        Boltzmann.logisticAccel(Xvec)      # Warmstart
+        tic(); 
+        for itr=1:Trials
+            Boltzmann.logisticAccel(Xvec)
+        end
+        tVAccel=toq()
+    println("   [Accel]   Vector ($N x 1): $tVAccel sec")
+
+    # Accel, Matrix
+        Boltzmann.logisticAccel(Xmat)        # Warmstart
+        tic(); 
+        for itr=1:Trials
+            Boltzmann.logisticAccel(Xmat)
+        end
+        tMAccel=toq()
+    println("   [Accel]   Matirx ($L x $L): $tMAccel sec")
+
+    vecBoost = tV./tVAccel
+    matBoost = tM./tMAccel
+    println("===================================================")
+    println("Vector Accel Calculation: $vecBoost Times Faster")
+    println("Matrix Accel Calculation: $matBoost Times Faster")
+    println("===================================================")
+end

--- a/test/testaccel.jl
+++ b/test/testaccel.jl
@@ -68,6 +68,7 @@ if usingApple
     NFeatures = 784
     NHidden = 300
     NTrain = 10000
+    Epochs = 5
 
     X = rand(NFeatures,NTrain)
     rbm = BernoulliRBM(NFeatures,NHidden)
@@ -76,22 +77,25 @@ if usingApple
     println("RBM Tests")
     println("===================================================")    
     info("WARMUP")
-    fit(rbm,X;accelerate=false)     # Warmup
+    fit(rbm,X;accelerate=false,n_iter=Epochs)     # Warmup
     info("No Accel")
     tic()
-        fit(rbm,X;accelerate=false)
+        fit(rbm,X;accelerate=false,n_iter=Epochs)
     tRBM = toq()
+    info("==> Walltime: $tRBM sec")
+    println("")
 
     info("WARMUP")
-    fit(rbm,X;accelerate=true)      # Warmup
+    fit(rbm,X;accelerate=true,n_iter=Epochs)      # Warmup
     info("With Accel")
     tic()
-        fit(rbm,X;accelerate=true)
+        fit(rbm,X;accelerate=true,n_iter=Epochs)
     tRBMAccel = toq()
+    info("==> Walltime: $tRBMAccel sec")
 
     rbmBoost = tRBM ./ tRBMAccel
 
     println("===================================================")
-    println("10 Iteration Accel PCD: $rbmBoost Times Faster")
+    println("$Epochs Iteration Accel PCD: $rbmBoost Times Faster")
     println("===================================================")
 end


### PR DESCRIPTION
Added in support for using AppleAccelerate.jl if the user specifies it via the `accelerate` flag. Also optimized the default logistic sigmoid and sampler code, taking advantage of Devectorize.jl.
